### PR TITLE
Parse docker run flags to allow non-detached containers

### DIFF
--- a/scripts/socketplane.sh
+++ b/scripts/socketplane.sh
@@ -393,7 +393,18 @@ container_run() {
         network=$2
         shift 2
     fi
-    cid=$(docker run --net=none $@)
+
+    attach="false"
+    if [ -z "$(echo "$@" | grep -e '-.*\?d.*\?')" ]; then
+        attach="true"
+    fi
+
+    if [ "$attach" = "false" ]; then
+         cid=$(docker run --net=none $@)
+    else
+         cid=$(docker run --net=none -d $@)
+    fi
+
     cPid=$(docker inspect --format='{{ .State.Pid }}' $cid)
     cName=$(docker inspect --format='{{ .Name }}' $cid)
 
@@ -402,7 +413,11 @@ container_run() {
 
     attach $result $cPid
 
-    echo $cid
+    if [ "$attach" = "false" ]; then
+        echo $cid
+    else
+        docker attach $cid
+    fi
 }
 
 container_stop() {


### PR DESCRIPTION
Added a basic check for the `-d` flag.
If it's present. Create container, add network, echo container ID
If not, add it, create container, add network and attach
Fixes #44

Signed-off-by: Dave Tucker dave@socketplane.io
