### PR TITLE
issue62 if a container doesnt exist at 'agent start' add one

### DIFF
--- a/scripts/socketplane.sh
+++ b/scripts/socketplane.sh
@@ -319,7 +319,8 @@ start_socketplane_image() {
     if [ -n "$(docker ps | grep socketplane/socketplane | awk '{ print $1 }')" ]; then
         log_info  "All Socketplane agent containers are started."
     else
-        log_info  "No Socketplane agent containers are started."
+        log_info  "No Socketplane agent containers are provisioned, starting one now."
+        start_socketplane
     fi
 }
 


### PR DESCRIPTION
details at: https://github.com/socketplane/socketplane/issues/62

Signed-off-by: Brent Salisbury brent@socketplane.io
