### PR TITLE
bug#60 Fedora SP image fails to start due to SELINUX

### DIFF
--- a/scripts/socketplane.sh
+++ b/scripts/socketplane.sh
@@ -191,6 +191,11 @@ install_ovs() {
     if command_exists ovsdb-server && command_exists ovs-vswitchd ; then
         log_step "Open vSwitch already installed!"
     else
+        if ! command getenforce  2>/dev/null || [[ $(getenforce) =~ Enforcing|Permissive ]] ; then
+        log_step "Checking Open vSwitch dependencies.."
+        $pkg install policycoreutils-python
+        sudo semodule -d openvswitch  2>/dev/null || true
+        fi
         log_step "Installing Open vSwitch.."
         $pkg install $ovs | indent
     fi


### PR DESCRIPTION
Disables the openvswitch module in selinux, but does not affect any other SELinux modules.

Signed-off-by: Brent Salisbury <brent@socketplane.io>