### PR TITLE
Starting a docker instance via socketplane returned: Cannot find device ""connection_details":"

### DIFF
--- a/scripts/socketplane.sh
+++ b/scripts/socketplane.sh
@@ -432,7 +432,7 @@ container_start() {
     cName=$(docker inspect --format='{{ .Name }}' $cid)
 
     json=$(curl -s -X GET http://localhost:6675/v0.1/connections/$cid)
-    result=$(echo $json | sed 's/[,{}]/\n/g' | sed 's/^".*":"\(.*\)"/\1/g' | awk -v RS="" '{ print $6, $7, $8, $9, $10 }')
+    result=$(echo $json | sed 's/[,{}]/\n/g' | sed 's/^".*":"\(.*\)"/\1/g' | awk -v RS="" '{ print $7, $8, $9, $10, $11 }')
 
     attach $result $cPid
 


### PR DESCRIPTION
Debug info prior to and after patch:
root@test-1:~# sudo socketplane -D start b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ shift
+ container_start b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ docker start b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ awk { print $1}
+ grep b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ docker ps --no-trunc=true
+ cid=b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ docker inspect --format={{ .State.Pid }} b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ cPid=9730
+ docker inspect --format={{ .Name }} b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ cName=/grave_kirch
+ curl -s -X GET http://localhost:6675/v0.1/connections/b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ json={"container_id":"b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae","container_name":"/grave_kirch","container_pid":"7632","network":"dmz","ovs_port_id":"ovseef0fb4","connection_details":{"name":"ovseef0fb4","ip":"10.3.0.6","subnet":"/16","mac":"02:42:0a:03:00:06","gateway":"10.3.0.1"}}
+ awk -v RS= { print $6, $7, $8, $9, $10 }
+ sed s/^".*":"\(.*\)"/\1/g
+ sed s/[,{}]/\n/g
+ echo {"container_id":"b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae","container_name":"/grave_kirch","container_pid":"7632","network":"dmz","ovs_port_id":"ovseef0fb4","connection_details":{"name":"ovseef0fb4","ip":"10.3.0.6","subnet":"/16","mac":"02:42:0a:03:00:06","gateway":"10.3.0.1"}}
+ result="connection_details": ovseef0fb4 10.3.0.6 /16 02:42:0a:03:00:06
+ attach "connection_details": ovseef0fb4 10.3.0.6 /16 02:42:0a:03:00:06 9730
+ [ ! -d /var/run/netns ]
+ [ -f /var/run/netns/9730 ]
+ rm -f /var/run/netns/9730
+ ln -s /proc/9730/ns/net /var/run/netns/9730
+ ip link set dev "connection_details": netns 9730
Cannot find device ""connection_details":"
root@test-1:~# sudo socketplane -D start b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ shift
+ container_start b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ docker start b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ awk { print $1}
+ grep b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ docker ps --no-trunc=true
+ cid=b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ docker inspect --format={{ .State.Pid }} b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ cPid=9730
+ docker inspect --format={{ .Name }} b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ cName=/grave_kirch
+ curl -s -X GET http://localhost:6675/v0.1/connections/b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
+ json={"container_id":"b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae","container_name":"/grave_kirch","container_pid":"7632","network":"dmz","ovs_port_id":"ovseef0fb4","connection_details":{"name":"ovseef0fb4","ip":"10.3.0.6","subnet":"/16","mac":"02:42:0a:03:00:06","gateway":"10.3.0.1"}}
+ awk -v RS= { print $7, $8, $9, $10, $11 }
+ sed s/^".*":"\(.*\)"/\1/g
+ sed s/[,{}]/\n/g
+ echo {"container_id":"b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae","container_name":"/grave_kirch","container_pid":"7632","network":"dmz","ovs_port_id":"ovseef0fb4","connection_details":{"name":"ovseef0fb4","ip":"10.3.0.6","subnet":"/16","mac":"02:42:0a:03:00:06","gateway":"10.3.0.1"}}
+ result=ovseef0fb4 10.3.0.6 /16 02:42:0a:03:00:06 10.3.0.1
+ attach ovseef0fb4 10.3.0.6 /16 02:42:0a:03:00:06 10.3.0.1 9730
+ [ ! -d /var/run/netns ]
+ [ -f /var/run/netns/9730 ]
+ rm -f /var/run/netns/9730
+ ln -s /proc/9730/ns/net /var/run/netns/9730
+ ip link set dev ovseef0fb4 netns 9730
+ ip netns exec 9730 ip link set dev ovseef0fb4 address 02:42:0a:03:00:06
+ ip netns exec 9730 ip link set dev ovseef0fb4 up
+ ip netns exec 9730 ip addr add 10.3.0.6/16 dev ovseef0fb4
+ ip netns exec 9730 ip route add default via 10.3.0.1
+ echo b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
b18e77ea67149461bf6ee3af20449be6d7b8e3714be3dd63b8107e0009f665ae
root@test-1:~#