### PR TITLE
Fixbug: socketplane start container error

### DIFF
--- a/scripts/socketplane.sh
+++ b/scripts/socketplane.sh
@@ -432,7 +432,7 @@ container_start() {
     cName=$(docker inspect --format='{{ .Name }}' $cid)
 
     json=$(curl -s -X GET http://localhost:6675/v0.1/connections/$cid)
-    result=$(echo $json | sed 's/[,{}]/\n/g' | sed 's/^".*":"\(.*\)"/\1/g' | awk -v RS="" '{ print $6, $7, $8, $9, $10 }')
+    result=$(echo $json | sed 's/[,{}]/\n/g' | sed 's/^".*":"\(.*\)"/\1/g' | awk -v RS="" '{ print $7, $8, $9, $10, $11 }')
 
     attach $result $cPid
 


### PR DESCRIPTION
When I use socketplane start container, I get the following error:
root@socketplane1:~# socketplane run -n net3 -itd ubuntu
ff6860956a4e3e68b80a4ec40e840432b85c7b57de42beacc51784f462ba4b34
root@socketplane1:~# socketplane stop ff6860956a4e3e68b80a4ec40e840432b85c7b57de42beacc51784f462ba4b34
ff6860956a4e3e68b80a4ec40e840432b85c7b57de42beacc51784f462ba4b34
root@socketplane1:~# socketplane start ff6860956a4e3e68b80a4ec40e840432b85c7b57de42beacc51784f462ba4b34
Cannot find device ""connection_details":"

This is because the wrong awk in socketplane.sh .