### PR TITLE
Fix Vagrant input file to comply w/ VirtualBox on Ubuntu

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       socketplane_ip = socketplane_ips[n]
       socketplane_index = n+1
       socketplane.vm.hostname = "socketplane-#{socketplane_index}"
-      socketplane.vm.network :private_network, ip: "#{socketplane_ip}", virtualbox__intnet: true
+      socketplane.vm.network :private_network, ip: "#{socketplane_ip}", virtualbox__intnet: "true"
       socketplane.vm.provider :virtualbox do |vb|
         vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
       end


### PR DESCRIPTION
ERROR:
socketplane$ vagrant up
Bringing machine 'socketplane-1' up with 'virtualbox' provider...
Bringing machine 'socketplane-2' up with 'virtualbox' provider...
Bringing machine 'socketplane-3' up with 'virtualbox' provider...
[...]
[socketplane-1] Running cleanup tasks for 'shell' provisioner...
/usr/lib/ruby/vendor_ruby/childprocess/abstract_process.rb:36:in `initialize': all arguments must be String: ["/usr/bin/VBoxManage", "modifyvm", "ae180dca-eb66-42a8-93f0-d6be90727091", "--nic1", "nat", "--nic2", "intnet", "--intnet2", true] (ArgumentError)
    from /usr/lib/ruby/vendor_ruby/childprocess.rb:19:in`new'
    from /usr/lib/ruby/vendor_ruby/childprocess.rb:19:in `new'
[...]

SYSTEM INFO:
(Ubuntu 14.04 LTS)
~$ uname -a
Linux xxxx 3.13.0-44-generic #73-Ubuntu SMP Tue Dec 16 00:22:43 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
~$
~$ virtualbox --help
Oracle VM VirtualBox Manager 4.3.20
[...]
~$ vagrant -v
Vagrant 1.4.3

CHANGE:
In Vgrantfile, changed virtualbox__intnet parameter to string form

NOTE:
Madhu verified change works on MAC

Signed-off-by: Alessandro Boch aboch@socketplane.io
