### PR TITLE
issue #97 fail yum package silently on Ubuntu OS

### DIFF
--- a/scripts/socketplane.sh
+++ b/scripts/socketplane.sh
@@ -193,7 +193,7 @@ install_ovs() {
     else
         if ! command getenforce  2>/dev/null || [[ $(getenforce) =~ Enforcing|Permissive ]] ; then
         log_step "Checking Open vSwitch dependencies.."
-        $pkg install policycoreutils-python
+        $pkg install policycoreutils-python 2>/dev/null || true
         sudo semodule -d openvswitch  2>/dev/null || true
         fi
         log_step "Installing Open vSwitch.."


### PR DESCRIPTION
This simply fails policycoreutils-python silently w/ a || true

Script continues on to install OVS.

https://github.com/socketplane/socketplane/issues/97

Signed-off-by: Brent Salisbury <brent@socketplane.io>