### PR TITLE
Fixbug: Install socketplane error on second server

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,7 +60,7 @@ if [ -t 0 ]; then
   socketplane install
 else
   if [ -z $BOOTSTRAP ]; then
-     BOOTSTRAP=false
+     export BOOTSTRAP=false
   fi
   socketplane install unattended
 fi


### PR DESCRIPTION
When I install socketplane on a second server, I get the following error:
root@socketplane2:/usr/bin# curl -sSL http://get.socketplane.io/ | sudo sh
...
+ sleep 3
+ [ -t 0 ]
+ [ -z ]
+ BOOTSTRAP=false
+ socketplane install unattended
Installing SocketPlane...
-----> Setting Linux Kernel Options
           net.ipv4.ip_forward = 1
           net.ipv4.icmp_echo_ignore_broadcasts = 0
-----> Curl already installed!
-----> Open vSwitch already installed!
-----> Setting OVSDB Listener
-----> Docker already installed!
-----> Starting the SocketPlane container
BOOTSTRAP not set