### PR TITLE
Enabled network_test

### DIFF
--- a/daemon/network_test.go
+++ b/daemon/network_test.go
@@ -4,18 +4,11 @@ import (
 	"fmt"
 	"net"
 	"testing"
-
-	"github.com/socketplane/socketplane/datastore"
 )
 
 var subnetArray []*net.IPNet
 
 func TestInit(t *testing.T) {
-	t.Skip("Skipping test while dependent on Consul")
-	err := datastore.Init("eth0", true)
-	if err != nil {
-		t.Error("Error starting Consul ", err)
-	}
 	_, ipNet1, _ := net.ParseCIDR("192.168.1.0/24")
 	_, ipNet2, _ := net.ParseCIDR("192.168.2.0/24")
 	_, ipNet3, _ := net.ParseCIDR("192.168.3.0/24")
@@ -26,36 +19,35 @@ func TestInit(t *testing.T) {
 }
 
 func TestNetworkCreate(t *testing.T) {
-	t.Skip("Skipping test while dependent on Consul")
 	for i := 0; i < len(subnetArray); i++ {
 		network, err := CreateNetwork(fmt.Sprintf("Network-%d", i+1), subnetArray[i])
-		if err != nil {
+		if network == nil {
 			t.Error("Error Creating network ", err)
+		} else if err != nil {
+			t.Log("Possibly a permission error. Run tests as sudo")
 		}
 		fmt.Println("Network Created Successfully", network)
 	}
 }
 
 func TestGetNetwork(t *testing.T) {
-	t.Skip("Skipping test while dependent on Consul")
 	for i := 0; i < 5; i++ {
-		network, _ := GetNetwork(fmt.Sprintf("Network-%d", i+1))
+		name := fmt.Sprintf("Network-%d", i+1)
+		network, err := GetNetwork(name)
 		if network == nil {
-			t.Error("Error GetNetwork")
+			t.Errorf("Error GetNetwork(%s) %v", name, err.Error())
 		} else if network.Subnet != subnetArray[i].String() {
 			t.Error("Network mismatch")
 		}
-		fmt.Println("GetNetwork : ", network)
+		fmt.Println("GetNetwork : ", network, err)
 	}
 }
 
 func TestCleanup(t *testing.T) {
-	t.Skip("Skipping test while dependent on Consul")
 	for i := 0; i < 5; i++ {
 		err := DeleteNetwork(fmt.Sprintf("Network-%d", i+1))
 		if err != nil {
 			t.Error("Error Deleting Network", err)
 		}
 	}
-	datastore.Leave()
 }

--- a/ipam/ipam_test.go
+++ b/ipam/ipam_test.go
@@ -9,10 +9,6 @@ import (
 )
 
 func TestInit(t *testing.T) {
-	err := datastore.Init("", true)
-	if err != nil {
-		t.Log("Error starting Consul . Not failing ", err)
-	}
 }
 
 func TestIpRelease(t *testing.T) {
@@ -93,5 +89,4 @@ func TestCleanup(t *testing.T) {
 	ecc.Delete(dataStore, "192.167.1.0/24")
 	ecc.Delete(dataStore, "192.168.0.0/16")
 	ecc.Delete(dataStore, "192.169.32.0/20")
-	datastore.Leave()
 }


### PR DESCRIPTION
network Create and Destroy apis calls a few netlink APIs that require
the sudo permission to run these tests.
If we cannot run these tests in sudo, it will incorrectly deem the tests
as failed. Hence, changes are made to the testing code to make sure we
dont fail for permission failure cases.

If our CI can be executed with sudo privilege, then the code-coverage
will automatically work better. But still the error condition must be
checked for the netlink APIs.

Signed-off-by: Madhu Venugopal <madhu@socketplane.io>