### PR TITLE
Dockerize Testing, Enable Tests Requiring Sudo, Update Docs

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,81 @@
+HACKING
+=======
+
+How to contribute to SocketPlane
+
+## Development Environment
+
+- [Golang](http://golang.org/doc/code.html)
+- [Docker](https://docs.docker.com/installation/#installation)
+- [Fig](http://www.fig.sh/install.html)
+
+The system running Docker must have the `openvswitch` kernel module must be loaded for the test suite to be run. You can load it using `modprobe openvswitch`
+
+Support for boot2docker is provided using @dave-tucker's [fork](https://github.com/dave-tucker/boot2docker/tree/openvswitch)
+
+```bash
+git clone https://github.com/dave-tucker/boot2docker.git
+git checkout openvswitch
+docker build -t boot2docker . && docker run --rm boot2docker > boot2docker.iso
+# if b2d is running, destroy it
+boot2docker destroy
+boot2docker init --iso="$(pwd)/boot2docker.iso"
+boot2docker up
+boot2docker ssh modprobe openvswitch
+```
+
+## Workflow
+
+We use the standard GitHub workflow which is made a lot easier by using [`hub`](https://hub.github.com/)
+
+1. Create a fork
+
+        hub fork
+
+2. Create a branch for your work
+
+        # For bugs
+        git checkout -b bug/42
+        # For long-lived feature branches
+        git checkout -b feature/something-cool
+
+3. Make your changes and commit
+
+        git add --all
+        git commit -s
+
+4. Push your changes to your GitHub fork
+
+        git push <github-user> <branch-name>
+
+5. Raise a Pull Request
+
+        git pull-request
+
+6. To make changes following a code review, checkout your working branch
+
+        git checkout <branch-name>
+
+7. Make changes and then commit
+
+        git add --all
+        git commit --amend
+        git push --force
+
+## Running the Tests
+
+To run the tests inside a Docker container
+
+```bash
+make test
+# or
+make test-all
+```
+
+To run the tests locally you must run Open vSwitch, either via `fig up -d` or by installing it through your distribution's package manager.
+
+```bash
+make test-local
+# or
+make test-all-local
+```

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 build:
 	docker build -t socketplane/socketplane .
 
+coverage:
+	gover
+	goveralls -coverprofile=gover.coverprofile -service=$(CI_SERVICE) -repotoken=$(COVERALLS_TOKEN)
+
 test:
 	fig up -d
 	docker run --privileged=true --net=host --rm -v $(shell pwd):/go/src/github.com/socketplane/socketplane -w /go/src/github.com/socketplane/socketplane davetucker/golang-ci:1.3 make test-local	
@@ -14,11 +18,11 @@ test-all:
 	fig stop
 
 test-local:
-	go test -covermode=count -test.short -coverprofile=daemon.cover.out -coverpkg=./... ./daemon
-	go test -covermode=count -test.short -coverprofile=datastore.cover.out -coverpkg=./... ./ipam
-	go test -covermode=count -test.short -coverprofile=socketplane.cover.out
+	go test -covermode=count -test.short -coverprofile=daemon.coverprofile -coverpkg=./... ./daemon
+	go test -covermode=count -test.short -coverprofile=datastore.coverprofile -coverpkg=./... ./ipam
+	go test -covermode=count -test.short -coverprofile=socketplane.coverprofile
 
 test-all-local:
-	go test -covermode=count -coverprofile=daemon.cover.out -coverpkg=./... ./daemon
-	go test -covermode=count -coverprofile=datastore.cover.out -coverpkg=./... ./ipam
-	go test -covermode=count -coverprofile=socketplane.cover.out
+	go test -covermode=count -coverprofile=daemon.coverprofile -coverpkg=./... ./daemon
+	go test -covermode=count -coverprofile=datastore.coverprofile -coverpkg=./... ./ipam
+	go test -covermode=count -coverprofile=socketplane.coverprofile

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,24 @@
+.PHONY: build test test-all test-local test-all-local
+
 build:
 	docker build -t socketplane/socketplane .
 
 test:
+	fig up -d
+	docker run --privileged=true --net=host --rm -v $(shell pwd):/go/src/github.com/socketplane/socketplane -w /go/src/github.com/socketplane/socketplane davetucker/golang-ci:1.3 make test-local	
+	fig stop
+
+test-all:
+	fig up -d
+	docker run --privileged=true --net=host --rm -v $(shell pwd):/go/src/github.com/socketplane/socketplane -w /go/src/github.com/socketplane/socketplane davetucker/golang-ci:1.3 make test-all-local
+	fig stop
+
+test-local:
 	go test -covermode=count -test.short -coverprofile=daemon.cover.out -coverpkg=./... ./daemon
 	go test -covermode=count -test.short -coverprofile=datastore.cover.out -coverpkg=./... ./ipam
 	go test -covermode=count -test.short -coverprofile=socketplane.cover.out
 
-test-all:
+test-all-local:
 	go test -covermode=count -coverprofile=daemon.cover.out -coverpkg=./... ./daemon
 	go test -covermode=count -coverprofile=datastore.cover.out -coverpkg=./... ./ipam
 	go test -covermode=count -coverprofile=socketplane.cover.out

--- a/README.md
+++ b/README.md
@@ -152,47 +152,7 @@ The Socketplane agent runs in its own container and you might find the following
 
 ## Hacking
 
-Hacking uses the standard GitHub workflow which is made a lot easier by using [`hub`](https://hub.github.com/)
-
-1. Clone this repository
-
-        git clone git@github.com:socketplane/socketplane
-
-2. Create a fork
-
-        hub fork
-
-3. Create a branch for your work
-
-        # For bugs
-        git checkout -b bug/42
-        # For long-lived feature branches
-        git checkout -b feature/something-cool
-
-4. Make your changes and commit
-
-        git add --all
-        git commit -s
-
-5. Push your changes to your GitHub fork
-
-        git push <github-user> <branch-name>
-
-6. Raise a Pull Request
-
-        git pull-request
-
-If you need to make changes to your pull request in response to commets etc...
-
-7. Checkout your working branch
-
-        git checkout <branch-name>
-
-8. Make changes and then commit
-
-        git add --all
-        git commit --amend
-        git push --force
+See [HACKING.md](HACKING.md)
 
 ## Contact us
 

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ dependencies:
 
 test:
   override:
-    - sudo -E make test:
+    - sudo -E make test-local:
         pwd: ../.go_workspace/src/${REPO_PATH}
   post:
     - sudo fig stop:

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -75,7 +75,9 @@ func CreateNetwork(id string, subnet *net.IPNet) (*Network, error) {
 		// Interface does not exist, use the generated subnet
 		gateway = ipam.Request(*subnet)
 		network = &Network{id, subnet.String(), gateway.String(), vlan}
-		AddInternalPort(ovs, defaultBridgeName, network.ID, vlan)
+		if err = AddInternalPort(ovs, defaultBridgeName, network.ID, vlan); err != nil {
+			return network, err
+		}
 		// TODO : Lame. Remove the sleep. This is required now to keep netlink happy
 		// in the next step to find the created interface.
 		time.Sleep(time.Second * 1)

--- a/daemon/network_test.go
+++ b/daemon/network_test.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"fmt"
+	"log"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/socketplane/socketplane/datastore"
@@ -11,8 +13,10 @@ import (
 var subnetArray []*net.IPNet
 
 func TestInit(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
+	if os.Getuid() != 0 {
+		msg := "Skipped test because it requires root privileges."
+		log.Printf(msg)
+		t.Skip(msg)
 	}
 	err := datastore.Init("eth0", true)
 	if err != nil {
@@ -28,8 +32,10 @@ func TestInit(t *testing.T) {
 }
 
 func TestNetworkCreate(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
+	if os.Getuid() != 0 {
+		msg := "Skipped test because it requires root privileges."
+		log.Printf(msg)
+		t.Skip(msg)
 	}
 	for i := 0; i < len(subnetArray); i++ {
 		network, err := CreateNetwork(fmt.Sprintf("Network-%d", i+1), subnetArray[i])
@@ -41,8 +47,10 @@ func TestNetworkCreate(t *testing.T) {
 }
 
 func TestGetNetwork(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
+	if os.Getuid() != 0 {
+		msg := "Skipped test because it requires root privileges."
+		log.Printf(msg)
+		t.Skip(msg)
 	}
 	for i := 0; i < 5; i++ {
 		network, _ := GetNetwork(fmt.Sprintf("Network-%d", i+1))
@@ -56,8 +64,10 @@ func TestGetNetwork(t *testing.T) {
 }
 
 func TestCleanup(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
+	if os.Getuid() != 0 {
+		msg := "Skipped test because it requires root privileges."
+		log.Printf(msg)
+		t.Skip(msg)
 	}
 	for i := 0; i < 5; i++ {
 		err := DeleteNetwork(fmt.Sprintf("Network-%d", i+1))

--- a/daemon/ovs_driver.go
+++ b/daemon/ovs_driver.go
@@ -289,7 +289,7 @@ func UpdatePortContext(ovs *libovsdb.OvsdbClient, portName string, key string, c
 	return nil
 }
 
-func AddInternalPort(ovs *libovsdb.OvsdbClient, bridgeName string, portName string, tag uint) {
+func AddInternalPort(ovs *libovsdb.OvsdbClient, bridgeName string, portName string, tag uint) error {
 	namedPortUuid := "port"
 	namedIntfUuid := "intf"
 
@@ -339,14 +339,18 @@ func AddInternalPort(ovs *libovsdb.OvsdbClient, bridgeName string, portName stri
 	reply, _ := ovs.Transact("Open_vSwitch", operations...)
 	if len(reply) < len(operations) {
 		log.Error("Number of Replies should be atleast equal to number of Operations")
+		return errors.New("Number of Replies should be atleast equal to number of Operations")
 	}
 	for i, o := range reply {
 		if o.Error != "" && i < len(operations) {
-			log.Errorf("Transaction Failed due to an error : %v details: %v in %v", o.Error, o.Details, operations[i])
+			msg := fmt.Sprintf("Transaction Failed due to an error : %v details: %v in %v", o.Error, o.Details, operations[i])
+			return errors.New(msg)
 		} else if o.Error != "" {
-			log.Errorf("Transaction Failed due to an error : %v", o.Error)
+			msg := fmt.Sprintf("Transaction Failed due to an error : %v", o.Error)
+			return errors.New(msg)
 		}
 	}
+	return nil
 }
 
 func populateCache(updates libovsdb.TableUpdates) {

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 if [ -z "$coveralls_token" ]; then
-	make test
+	make test-local
 else
-	make test-all
+	make test-all-local
 fi
 


### PR DESCRIPTION
This PR Dockerize's the testing so that it is portable - you can run tests from OSX without getting complaints about Netlink @nerdalert 

We enable the tests that were disabled as they required sudo, and include logic to skip them if tests are not being run as the root user.

Finally, I've moved the Hacking section out of README.md to HACKING.md and added sections on Development Environment and Running the Tests