### PR TITLE
Updating docker-compose to the official docker-ovs image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ovs:
- image: davetucker/docker-ovs:2.3.0
+ image: socketplane/docker-ovs:2.3.0
  command: "/usr/bin/supervisord -n"
  cap_add: 
    - NET_ADMIN


### PR DESCRIPTION
Huge thanks to Dave for maintaining the docker-ovs image.
Populated the socketplane/docker-ovs repo with the official containers
and hence we can start using it.

Signed-off-by: Madhu Venugopal <madhu@socketplane.io>