### PR TITLE
Docker Compose with socketplane, docker-ovs and powerstrip containers. Includes OVS disconnect handling.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -188,8 +188,8 @@
 		},
 		{
 			"ImportPath": "github.com/socketplane/libovsdb",
-			"Comment": "v0.1",
-			"Rev": "555a561202ec17fe6c068038a35291ce9ba33066"
+			"Comment": "v0.1-2-g58cf012",
+			"Rev": "58cf01279880d621a67c5f929af9ed59ab409373"
 		},
 		{
 			"ImportPath": "github.com/vishvananda/netlink",

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/client.go
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/client.go
@@ -88,6 +88,8 @@ type NotificationHandler interface {
 
 	// RFC 7047 section 4.1.11 Echo Notification
 	Echo([]interface{})
+
+	Disconnected(*OvsdbClient)
 }
 
 // RFC 7047 : Section 4.1.6 : Echo
@@ -174,9 +176,9 @@ func (ovs OvsdbClient) Transact(database string, operation ...Operation) ([]Oper
 	args := NewTransactArgs(database, operation...)
 	err := ovs.rpcClient.Call("transact", args, &reply)
 	if err != nil {
-		log.Fatal("transact failure", err)
+		return nil, err
 	}
-	return reply, err
+	return reply, nil
 }
 
 // Convenience method to monitor every table/column
@@ -231,7 +233,14 @@ func getTableUpdatesFromRawUnmarshal(raw map[string]map[string]RowUpdate) TableU
 }
 
 func clearConnection(c *rpc2.Client) {
-	connections[c] = nil
+	if _, ok := connections[c]; ok {
+		for _, handler := range connections[c].handlers {
+			if handler != nil {
+				handler.Disconnected(connections[c])
+			}
+		}
+	}
+	delete(connections, c)
 }
 
 func handleDisconnectNotification(c *rpc2.Client) {

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/example/play_with_ovs.go
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/example/play_with_ovs.go
@@ -28,6 +28,7 @@ func play(ovs *libovsdb.OvsdbClient) {
 							name := newRow.Fields["name"].(string)
 							if name == "stop" {
 								fmt.Println("Bridge stop detected : ", uuid)
+								ovs.Disconnect()
 								quit <- true
 							}
 						}
@@ -159,4 +160,6 @@ func (n Notifier) Locked([]interface{}) {
 func (n Notifier) Stolen([]interface{}) {
 }
 func (n Notifier) Echo([]interface{}) {
+}
+func (n Notifier) Disconnected(client *libovsdb.OvsdbClient) {
 }

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/ovs_integration_test.go
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/ovs_integration_test.go
@@ -294,6 +294,8 @@ func (n Notifier) Stolen([]interface{}) {
 func (n Notifier) Echo([]interface{}) {
 	n.echoChan <- true
 }
+func (n Notifier) Disconnected(client *OvsdbClient) {
+}
 
 func TestDBSchemaValidation(t *testing.T) {
 

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,12 @@ coverage:
 
 test:
 	docker-compose up -d ovs
-	docker run --cap-add=NET_ADMIN --cap-add SYS_ADMIN --net=container:socketplane_ovs_1 --rm -v $(shell pwd):/go/src/github.com/socketplane/socketplane -w /go/src/github.com/socketplane/socketplane davetucker/golang-ci:1.3 make test-local	
+	docker run --cap-add=NET_ADMIN --cap-add SYS_ADMIN --net=host --rm -v $(shell pwd):/go/src/github.com/socketplane/socketplane -w /go/src/github.com/socketplane/socketplane davetucker/golang-ci:1.3 make test-local	
 	docker-compose stop
 
 test-all:
 	docker-compose up -d ovs
-	docker run --cap-add=NET_ADMIN --cap-add SYS_ADMIN --net=container:socketplane_ovs_1 --rm -v $(shell pwd):/go/src/github.com/socketplane/socketplane -w /go/src/github.com/socketplane/socketplane davetucker/golang-ci:1.3 make test-all-local
+	docker run --cap-add=NET_ADMIN --cap-add SYS_ADMIN --net=host --rm -v $(shell pwd):/go/src/github.com/socketplane/socketplane -w /go/src/github.com/socketplane/socketplane davetucker/golang-ci:1.3 make test-all-local
 	docker-compose stop
 
 test-local:

--- a/daemon/bridge.go
+++ b/daemon/bridge.go
@@ -64,6 +64,8 @@ func OvsInit() {
 	ovs, err = ovs_connect()
 	if err != nil {
 		log.Error("Error connecting OVS ", err)
+	} else {
+		ovs.Register(notifier{})
 	}
 	ContextCache = make(map[string]string)
 	populateContextCache()
@@ -448,4 +450,22 @@ func installRule(args ...string) ([]byte, error) {
 	}
 
 	return output, err
+}
+
+type notifier struct {
+}
+
+func (n notifier) Disconnected(ovsClient *libovsdb.OvsdbClient) {
+	log.Error("OVS Disconnected. Retrying...")
+	ovs = nil
+	go OvsInit()
+}
+
+func (n notifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
+}
+func (n notifier) Locked([]interface{}) {
+}
+func (n notifier) Stolen([]interface{}) {
+}
+func (n notifier) Echo([]interface{}) {
 }

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -71,6 +71,9 @@ func CreateNetwork(id string, subnet *net.IPNet) (*Network, error) {
 	addr, err := GetIfaceAddr(id)
 	if err != nil {
 		log.Debugf("Interface with name %s does not exist. Creating it.", id)
+		if ovs == nil {
+			return nil, errors.New("OVS not connected")
+		}
 		// Interface does not exist, use the generated subnet
 		gateway = ipam.Request(*subnet)
 		network = &Network{id, subnet.String(), gateway.String(), vlan}
@@ -127,6 +130,9 @@ func DeleteNetwork(id string) error {
 	network, err := GetNetwork(id)
 	if err != nil {
 		return err
+	}
+	if ovs == nil {
+		return errors.New("OVS not connected")
 	}
 	eccerror := ecc.Delete(networkStore, id)
 	if eccerror != ecc.OK {

--- a/daemon/ovs_driver.go
+++ b/daemon/ovs_driver.go
@@ -408,6 +408,8 @@ func (n Notifier) Update(context interface{}, tableUpdates libovsdb.TableUpdates
 	populateCache(tableUpdates)
 	update <- &tableUpdates
 }
+func (n Notifier) Disconnected(ovsClient *libovsdb.OvsdbClient) {
+}
 func (n Notifier) Locked([]interface{}) {
 }
 func (n Notifier) Stolen([]interface{}) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,26 @@
+socketplane:
+ image: socketplane/socketplane
+ volumes:
+   - /etc/socketplane/socketplane.toml:/etc/socketplane/socketplane.toml
+   - /var/run/docker.sock:/var/run/docker.sock
+   - /usr/bin/docker:/usr/bin/docker
+   - /proc:/hostproc
+ command: "socketplane"
+ net: "host"
+ privileged: true
+ environment:
+   PROCFS: /hostproc
 ovs:
  image: socketplane/docker-ovs:2.3.0
  command: "/usr/bin/supervisord -n"
- cap_add: 
+ net: "host"
+ volumes:
+   - /etc/openvswitch/
+ cap_add:
    - NET_ADMIN
+powerstrip:
+ image: clusterhq/powerstrip:v0.0.1
+ net: "host"
+ volumes:
+   - /etc/socketplane/adapters.yml:/etc/powerstrip/adapters.yml
+   - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
This PR depends on #144 entirely. I opened this to get inputs from you guys.
Please dont merge.

Things to consider / discuss :
* socketplane container still requires `privileged=true`. The capabilities `SYS_ADMIN` & `NET_ADMIN` are not enough in order for us to manipulate other container's namespace.
* Please note that docker-compose cfgs are not a very programmable entity. In order to use it effectively (such as `modprobe openvswitch`), we need to have some external logic in the script that compensates for the lack of programmability in docker-compose config files. This commit doesn't address the scripting changes. It will be addressed in subsequent commits.
* still using docker-ovs due to the nasty timing issues which calls for proper FSM which @dave-tucker is looking into.


Signed-off-by: Madhu Venugopal <madhu@socketplane.io>