### PR TITLE
Add support for go-dockerclient and fix small error

### DIFF
--- a/adapters.yml
+++ b/adapters.yml
@@ -6,5 +6,10 @@ endpoints:
     post: [socketplane]
   "DELETE /*/containers/*":
     post: [socketplane]
+  "POST /containers/*/start":
+    pre: [socketplane]
+    post: [socketplane]
+  "DELETE /containers/*":
+    post: [socketplane]
 adapters:
   socketplane: http://localhost:6675/adapter

--- a/daemon/powerstrip.go
+++ b/daemon/powerstrip.go
@@ -85,7 +85,16 @@ func psAdapterPostHook(d *Daemon, reqParams adapterRequest) (postResp *adapterPo
 	if reqParams.ClientRequest.Request != "" {
 		// start api looks like this /<version>/containers/<cid>/start
 		s := regexp.MustCompile("/").Split(reqParams.ClientRequest.Request, 5)
-		cid := s[3]
+		var cid string
+
+		if strings.HasPrefix(reqParams.ClientRequest.Request, "/v") {
+			// start api looks like this /<version>/containers/<cid>/start
+			cid = s[3]
+
+		} else {
+			// start api looks like this /containers/<cid>/start for the fsouza/go-dockerclient without api version
+			cid = s[2]
+		}
 
 		var cfg = &Connection{}
 		var op = ConnectionAdd

--- a/scripts/socketplane.sh
+++ b/scripts/socketplane.sh
@@ -137,7 +137,7 @@ deps() {
     echo ".... Docker Server Version:   1.4 or higher"
     echo "....   Current:               $DOCKER_SVER"
     echo ".... Docker Client Version:   1.16 or higher"
-    echo "....   Current:               $DOCKER_SVER"
+    echo "....   Current:               $DOCKER_CVER"
 }
 
 kernel_opts(){


### PR DESCRIPTION
Recently I was working on a project to integrate socketplane into kubernetes. I was using it with powerstrip. The kubernetes is using `fsouza/go-dockerclient` which is not working with the socketplane adapter first.

After some debugging time, I found that `fsouza/go-dockerclient` does not send API version info along with the container create and start request which causes this problem.

So I made some changes to the adapters.yml and found a little bug code when showing the socketplane deps. 
I have tested in my local environment and the new version of socketplane works with docker cli command and fsouza/go-dockerclient smoothly.